### PR TITLE
soong: Add qti vibrator effect stream config

### DIFF
--- a/build/soong/Android.bp
+++ b/build/soong/Android.bp
@@ -421,3 +421,27 @@ surfaceflinger_qcom_extensions {
         },
     },
 }
+
+soong_config_module_type {
+    name: "qti_vibrator_hal",
+    module_type: "cc_defaults",
+    config_namespace: "lineageQcomVars",
+    bool_variables: ["qti_vibrator_use_effect_stream"],
+    value_variables: ["qti_vibrator_effect_lib"],
+    properties: [
+        "cppflags",
+        "shared_libs",
+    ],
+}
+
+qti_vibrator_hal {
+    name: "qti_vibrator_hal_defaults",
+    soong_config_variables: {
+        qti_vibrator_use_effect_stream: {
+            cppflags: ["-DUSE_EFFECT_STREAM"],
+        },
+        qti_vibrator_effect_lib: {
+            shared_libs: ["%s"],
+        },
+    },
+}

--- a/config/BoardConfigSoong.mk
+++ b/config/BoardConfigSoong.mk
@@ -56,6 +56,8 @@ SOONG_CONFIG_risingNvidiaVars += \
 
 SOONG_CONFIG_NAMESPACES += risingQcomVars
 SOONG_CONFIG_risingQcomVars += \
+    qti_vibrator_effect_lib \
+    qti_vibrator_use_effect_stream \
     supports_extended_compress_format \
     uses_pre_uplink_features_netmgrd
 
@@ -73,6 +75,7 @@ SOONG_CONFIG_risingGlobalVars_gralloc_handle_has_ubwcp_format := $(TARGET_GRALLO
 SOONG_CONFIG_risingGlobalVars_inline_kernel_building := $(INLINE_KERNEL_BUILDING)
 SOONG_CONFIG_risingGlobalVars_uses_egl_display_array := $(TARGET_USES_EGL_DISPLAY_ARRAY)
 SOONG_CONFIG_risingNvidiaVars_uses_nvidia_enhancements := $(NV_ANDROID_FRAMEWORK_ENHANCEMENTS)
+SOONG_CONFIG_risingQcomVars_qti_vibrator_use_effect_stream := $(TARGET_QTI_VIBRATOR_USE_EFFECT_STREAM)
 SOONG_CONFIG_risingQcomVars_supports_extended_compress_format := $(AUDIO_FEATURE_ENABLED_EXTENDED_COMPRESS_FORMAT)
 SOONG_CONFIG_risingQcomVars_uses_pre_uplink_features_netmgrd := $(TARGET_USES_PRE_UPLINK_FEATURES_NETMGRD)
 
@@ -89,6 +92,7 @@ TARGET_HEALTH_CHARGING_CONTROL_SUPPORTS_BYPASS ?= true
 TARGET_HEALTH_CHARGING_CONTROL_SUPPORTS_DEADLINE ?= false
 TARGET_HEALTH_CHARGING_CONTROL_SUPPORTS_TOGGLE ?= true
 TARGET_INIT_VENDOR_LIB ?= vendor_init
+TARGET_QTI_VIBRATOR_EFFECT_LIB ?= libqtivibratoreffect
 TARGET_SURFACEFLINGER_UDFPS_LIB ?= surfaceflinger_udfps_lib
 TARGET_TRUST_USB_CONTROL_PATH ?= /proc/sys/kernel/deny_new_usb
 TARGET_TRUST_USB_CONTROL_ENABLE ?= 1
@@ -116,3 +120,4 @@ SOONG_CONFIG_risingQcomVars_qcom_display_headers_namespace := vendor/qcom/openso
 else
 SOONG_CONFIG_risingQcomVars_qcom_display_headers_namespace := $(QCOM_SOONG_NAMESPACE)/display
 endif
+SOONG_CONFIG_risingQcomVars_qti_vibrator_effect_lib := $(TARGET_QTI_VIBRATOR_EFFECT_LIB)


### PR DESCRIPTION
Fixes the error due to latest LOS changes to vendor/qcom/opensource/vibrator

FAILED: converting Android.bp files to BUILD files at out/soong/bp2build
Outputs: out/soong/bp2build_files_marker
Error: exited with code: 1
Command: cd "$(dirname "out/host/linux-x86/bin/soong_build")" && BUILDER="$PWD/$(basename "out/host/linux-x86/bin/soong_build")" && cd / && env -i  "$BUILDER"     --top "$TOP"     --soong_out "out/soong"     --out "out"     --bp2build_marker out/soong/bp2build_files_marker --globListDir bp2build_files --globFile out/soong/globs-bp2build_files.ninja -t -l out/.module_paths/Android.bp.list --available_env out/soong/soong.environment.available --used_env out/soong/soong.environment.used.bp2build_files Android.bp
Output:
[31merror:[0m vendor/qcom/opensource/vibrator/aidl/Android.bp:36:1: "vendor.qti.hardware.vibrator.impl" depends on undefined module "qti_vibrator_hal_defaults".
Or did you mean ["libqti_vndfwk_detect_system" "libqti_vndfwk_detect_vendor" "libvibratorservice_test" "libvirtualtouchpadclient" "tz_version-art-test-tzdata" "webrtc_video__video_frame" "xhci_device.policy_x86_64"]?

